### PR TITLE
Add facility code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ callbacks based on receiving a card number from a
 ## Example usage:
 
     from wiegand import Wiegand
-
+    VALID_FACILITY_CODEs = [ '123']
     VALID_CARDS = [ '12345' ]
 
     GREEN_LED = Pin(...)
@@ -18,8 +18,8 @@ callbacks based on receiving a card number from a
     WIEGAND_ZERO = XX  # Pin number here
     WIEGAND_ONE = YY   # Pin number here
 
-    def on_card(card_number, cards_read):
-	if card_number in VALID_CARDS:
+    def on_card(card_number, facility_code, cards_read):
+	if (card_number in VALID_CARDS) and (facility_code in VALID_FACILITY_CODES):
 	    GREEN_LED.high()
 	    RED_LED.low()
 	else:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ callbacks based on receiving a card number from a
 ## Example usage:
 
     from wiegand import Wiegand
-    VALID_FACILITY_CODEs = [ '123']
+    VALID_FACILITY_CODES = [ '123']
     VALID_CARDS = [ '12345' ]
 
     GREEN_LED = Pin(...)

--- a/wiegand.py
+++ b/wiegand.py
@@ -8,6 +8,7 @@ from machine import Pin, Timer
 import utime
 
 CARD_MASK = 0b11111111111111110 # 16 ones
+FACILITY_MASK = 0b11111111 # 8 ones
 
 # Max pulse interval: 2ms
 # pulse width: 50us
@@ -52,6 +53,12 @@ class Wiegand:
         if self.last_card is None:
             return None
         return ( self.last_card & CARD_MASK ) >> 1
+        
+    def get_facility_code(self):
+        if self.last_card is None:
+            return None
+        # Specific to standard 26bit wiegand
+        return ( self.last_card >> 17 ) & FACILITY_MASK
 
     def _cardcheck(self, t):
         if self.last_bit_read is None: return
@@ -63,5 +70,4 @@ class Wiegand:
             self.next_card = 0
             self._bits = 0
             self.cards_read += 1
-            self.callback(self.get_card(), self.cards_read)
-
+            self.callback(self.get_card(), self.get_facility_code(), self.cards_read)

--- a/wiegand.py
+++ b/wiegand.py
@@ -8,7 +8,7 @@ from machine import Pin, Timer
 import utime
 
 CARD_MASK = 0b11111111111111110 # 16 ones
-FACILITY_MASK = 0b11111111 # 8 ones
+FACILITY_MASK = 0b1111111100000000000000000 # 8 ones
 
 # Max pulse interval: 2ms
 # pulse width: 50us
@@ -58,7 +58,7 @@ class Wiegand:
         if self.last_card is None:
             return None
         # Specific to standard 26bit wiegand
-        return ( self.last_card >> 17 ) & FACILITY_MASK
+        return ( self.last_card & FACILITY_MASK ) >> 17
 
     def _cardcheck(self, t):
         if self.last_bit_read is None: return


### PR DESCRIPTION
Added the ability to use Facility Codes in the Wiegand format.

I followed the data format listed here:
https://www.hidglobal.com/sites/default/files/hid-understanding_card_data_formats-wp-en.pdf

I've tested this with a HID Prox TAG and a genuine HID Prox reader sending in the wiegand format.